### PR TITLE
Fix pollution of `includedUnits` defaults

### DIFF
--- a/.changeset/forty-items-spend.md
+++ b/.changeset/forty-items-spend.md
@@ -1,0 +1,5 @@
+---
+"enhanced-ms": patch
+---
+
+Fixed handling of `includeMs` and `includeSubMs` options

--- a/src/format/helpers/resolve-options.ts
+++ b/src/format/helpers/resolve-options.ts
@@ -94,7 +94,7 @@ export function resolveFormatOptions(options: Omit<FormatOptions, 'extends'>) {
     includeZero = defaultFormatOptions.includeZero,
     includeMs = defaultFormatOptions.includeMs,
     includeSubMs = defaultFormatOptions.includeSubMs,
-    includedUnits = defaultFormatOptions.includedUnits,
+    includedUnits = [...defaultFormatOptions.includedUnits],
     unitLimit = defaultFormatOptions.unitLimit,
     unitSeparator = defaultFormatOptions.unitSeparator,
     minimumDigits = defaultFormatOptions.minimumDigits,


### PR DESCRIPTION
With the 4.0.0 release of _enhanced-ms_, passing `includeMs: true` to the format method causes subsequent calls to always include milliseconds in the resulting string, even when `includeMs: false` is specified:

```js
import { ms } from 'enhanced-ms';

console.log(ms(1001, { includeMs: false }));
// -> 1 second ✅
console.log(ms(1001, { includeMs: true }));
// -> 1 second 1 millisecond ✅
console.log(ms(1001, { includeMs: false }));
// -> 1 second 1 millisecond ❌
```

The same issue occurs with `includeSubMs: true` for microseconds and nanoseconds.

The bug stems from the `resolveFormatOptions` method, which modifies the original `defaultFormatOptions.includedUnits` array here:

https://github.com/apteryxxyz/enhanced-ms/blob/f119aff3969e72524a74139c3efca7081ab91597/src/format/helpers/resolve-options.ts#L133-L134

This PR fixes it by simply creating a copy of said array.
